### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -5,19 +5,19 @@ redis2hdfs
    :target: https://travis-ci.org/xiaogaozi/redis2hdfs
    :alt: Build Status
 
-.. image:: https://pypip.in/version/redis2hdfs/badge.svg?style=flat
+.. image:: https://img.shields.io/pypi/v/redis2hdfs.svg?style=flat
    :target: https://pypi.python.org/pypi/redis2hdfs
    :alt: Latest Version
 
-.. image:: https://pypip.in/py_versions/redis2hdfs/badge.svg?style=flat
+.. image:: https://img.shields.io/pypi/pyversions/redis2hdfs.svg?style=flat
    :target: https://pypi.python.org/pypi/redis2hdfs
    :alt: Supported Python versions
 
-.. image:: https://pypip.in/status/redis2hdfs/badge.svg?style=flat
+.. image:: https://img.shields.io/pypi/status/redis2hdfs.svg?style=flat
    :target: https://pypi.python.org/pypi/redis2hdfs
    :alt: Development Status
 
-.. image:: https://pypip.in/license/redis2hdfs/badge.svg?style=flat
+.. image:: https://img.shields.io/pypi/l/redis2hdfs.svg?style=flat
    :target: https://pypi.python.org/pypi/redis2hdfs
    :alt: License
 


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20redis2hdfs))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `redis2hdfs`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badges to use shields.io instead.